### PR TITLE
修复Marshall在鸿蒙系统移动设备中不用的问题。

### DIFF
--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Runtime)
 # Include auto-generated files on include path
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if (CLR_CMAKE_TARGET_APPLE)
+if (CLR_CMAKE_TARGET_APPLE OR CLR_CMAKE_TARGET_LINUX_MUSL)
   list(APPEND RUNTIME_SOURCES_ARCH_ASM
     ${ARCH_SOURCES_DIR}/ThunkPoolThunks.${ASM_SUFFIX}
   )

--- a/src/coreclr/nativeaot/Runtime/ThunksMapping.cpp
+++ b/src/coreclr/nativeaot/Runtime/ThunksMapping.cpp
@@ -359,7 +359,7 @@ EXTERN_C void* QCALLTYPE RhAllocateThunksMapping()
     int thunkBlockSize = RhpGetThunkBlockSize();
     int templateSize = thunkBlocksPerMapping * thunkBlockSize;
 
-#ifndef TARGET_APPLE // Apple platforms cannot use the initial template
+#ifndef TARGET_APPLE || TARGET_LINUX // Apple platforms cannot use the initial template
     if (pThunksTemplateAddress == NULL)
     {
         // First, we use the thunks directly from the thunks template sections in the module until all
@@ -377,8 +377,9 @@ EXTERN_C void* QCALLTYPE RhAllocateThunksMapping()
         uint8_t* pModuleBase = (uint8_t*)PalGetModuleHandleFromPointer(RhpGetThunksBase());
         int templateRva = (int)((uint8_t*)RhpGetThunksBase() - pModuleBase);
 
-        if (!PalAllocateThunksFromTemplate((HANDLE)pModuleBase, templateRva, templateSize, &pThunkMap))
+        if (!PalAllocateThunksFromTemplate((HANDLE)pModuleBase, templateRva, templateSize, &pThunkMap)){
             return NULL;
+        }
     }
 
     if (!PalMarkThunksAsValidCallTargets(

--- a/src/coreclr/nativeaot/Runtime/arm64/ThunkPoolThunks.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/ThunkPoolThunks.S
@@ -12,17 +12,17 @@
 
 #define THUNKS_MAP_SIZE 0x8000
 
-#ifdef TARGET_APPLE
-#define PAGE_SIZE 0x4000
-#define PAGE_SIZE_LOG2 14
+#ifdef TARGET_LINUX
+#define PAGE_SIZE 0x1000
+#define PAGE_SIZE_LOG2 12
 #else
 #error Unsupported OS
 #endif
 
 // THUNK_POOL_NUM_THUNKS_PER_PAGE = min(PAGE_SIZE / THUNK_CODESIZE, (PAGE_SIZE - POINTER_SIZE) / THUNK_DATASIZE)
-#define THUNK_POOL_NUM_THUNKS_PER_PAGE 0x3ff
+#define THUNK_POOL_NUM_THUNKS_PER_PAGE 0xFF
 
-//;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Thunk Pages ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+#ifdef TARGET_LINUX
 
 .macro THUNKS_PAGE_BLOCK
     IN_PAGE_INDEX = 0
@@ -45,16 +45,17 @@
     .endr
 .endm
 
-#ifdef TARGET_APPLE
 // Thunk pool
-    .text
+    .section .thunks ,"ax"
     .p2align PAGE_SIZE_LOG2
 PATCH_LABEL ThunkPool
     .rept (THUNKS_MAP_SIZE / PAGE_SIZE)
     .p2align PAGE_SIZE_LOG2
     THUNKS_PAGE_BLOCK
     .endr
+    .space THUNKS_MAP_SIZE
     .p2align PAGE_SIZE_LOG2
+    .section .text
 #else
 #error Unsupported OS
 #endif
@@ -66,8 +67,8 @@ PATCH_LABEL ThunkPool
 //
 LEAF_ENTRY RhpGetThunksBase
     // Return the address of the first thunk pool to the caller (this is really the base address)
-    adrp     x0, C_FUNC(ThunkPool)@PAGE
-    add      x0, x0, C_FUNC(ThunkPool)@PAGEOFF
+    adrp     x0, C_FUNC(ThunkPool)
+    add      x0, x0, #:lo12:C_FUNC(ThunkPool)
     ret
 LEAF_END RhpGetThunksBase
 


### PR DESCRIPTION
Fixes Issue <!-- Issue Number -->

main PR <!-- Link to PR if any that fixed this in the main branch. -->

# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

# Testing

<!-- What kind of testing has been done with the fix. -->

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.